### PR TITLE
Add Devtools project

### DIFF
--- a/bots/newsbot-config.toml
+++ b/bots/newsbot-config.toml
@@ -82,3 +82,12 @@ description = '**Ansible** is the full-fat package containing Ansible Core & the
 website = 'https://github.com/ansible-collections'
 default_section = 'releases'
 usual_reporters = []
+
+[[projects]]
+emoji = '⛏️' # :pick:
+name = 'devtools'
+title = 'DevTools'
+description = 'VScode extension, language server, linter, molecule, runner, navigator and potentially other development goodies'
+website = 'https://github.com/ansible/vscode-ansible'
+default_section = 'releases'
+usual_reporters = []


### PR DESCRIPTION
For @cybette 

Wasn;t sure about the URL, couldn't find a "team repo", so I used the vscode one for now. Not sure if we need a "team updates" section to default to, but I figure releases is a good enough default until we known what else we need.

If/when merged, run !update-config in the bot admin room