### PR TITLE
Replace past issues to point to forum

### DIFF
--- a/bots/newsbot-report.md
+++ b/bots/newsbot-report.md
@@ -9,7 +9,7 @@ draft: false
 ---
 
 *This week in Ansible Community*
-*Issue #{{weeknumber}}, {{today}} ([Past Issues](https://us19.campaign-archive.com/home/?u=56d874e027110e35dea0e03c1&id=d6635f5420))*
+*Issue #{{weeknumber}}, {{today}} ([Past Issues](https://forum.ansible.com/c/news/bullhorn/17))*
 
 Welcome to [The Bullhorn](https://github.com/ansible/community/wiki/News#the-bullhorn), our newsletter for the Ansible Community. If you have any questions or content you’d like to share, you're welcome to chat with us in the [Ansible Social room on Matrix](https://matrix.to/#/#social:ansible.com), and mention [`newsbot`](https://matrix.to/#/@newsbot:ansible.im) to have your news item tagged for review for the next weekly issue!
 

--- a/bots/newsbot-report.md
+++ b/bots/newsbot-report.md
@@ -11,7 +11,7 @@ draft: false
 *This week in Ansible Community*
 *Issue #{{weeknumber}}, {{today}} ([Past Issues](https://forum.ansible.com/c/news/bullhorn/17))*
 
-Welcome to [The Bullhorn](https://github.com/ansible/community/wiki/News#the-bullhorn), our newsletter for the Ansible Community. If you have any questions or content you’d like to share, you're welcome to chat with us in the [Ansible Social room on Matrix](https://matrix.to/#/#social:ansible.com), and mention [`newsbot`](https://matrix.to/#/@newsbot:ansible.im) to have your news item tagged for review for the next weekly issue!
+Welcome to [The Bullhorn](https://forum.ansible.com/c/news/bullhorn/17), our newsletter for the Ansible Community. If you have any questions or content you’d like to share, you're welcome to chat with us in the [Ansible Social room on Matrix](https://matrix.to/#/#social:ansible.com), and mention [`newsbot`](https://matrix.to/#/@newsbot:ansible.im) to have your news item tagged for review for the next weekly issue!
 
 {{sections}}
 


### PR DESCRIPTION
Mailchimp will eventually go away so let's get people looking at the forum for older posts now.