### PR TITLE
Update boilerplate additions

### DIFF
--- a/bots/newsbot-config.toml
+++ b/bots/newsbot-config.toml
@@ -40,7 +40,6 @@ usual_reporters = []
 emoji = '🏆️' # :trophy:
 name = 'releases'
 title = 'Major new releases'
-description = "See Ansible Forum [releases](https://forum.ansible.com/c/news/releases/18) for more of this week's releases."
 order = 102
 usual_reporters = []
 
@@ -62,7 +61,6 @@ usual_reporters = []
 emoji = '🙏' # :pray:
 name = 'help'
 title = 'Help wanted'
-description = 'We are always looking for help fixing issues in [collections](https://github.com/search?q=user:ansible-collections+label:easyfix,"good+first+issue"+state:open&type=Issues) and [other projects](https://github.com/search?q=user:ansible+user:ansible-community+label:easyfix,"good+first+issue"+state:open&type=Issues)!'
 order = 105
 usual_reporters = []
 
@@ -84,7 +82,6 @@ usual_reporters = []
 emoji = '📅' # :date:
 name = 'events'
 title = 'Community events and meetups'
-description = "See the Ansible Forum [events calendar](https://forum.ansible.com/c/events/8) for upcoming events."
 order = 108
 usual_reporters = []
 

--- a/bots/newsbot-report.md
+++ b/bots/newsbot-report.md
@@ -8,12 +8,18 @@ categories: ["weekly-update"]
 draft: false
 ---
 
-# This week in Ansible Community
+**This week in Ansible Community**
 *Issue #{{weeknumber}}, {{today}} ([Past Issues](https://forum.ansible.com/c/news/bullhorn/17))*
 
 Welcome to [The Bullhorn](https://forum.ansible.com/c/news/bullhorn/17), our newsletter for the Ansible Community. If you have any questions or content you’d like to share, you're welcome to chat with us in the [Ansible Social room on Matrix](https://matrix.to/#/#social:ansible.com), and mention [`newsbot`](https://matrix.to/#/@newsbot:ansible.im) to have your news item tagged for review for the next weekly issue!
 
 {{sections}}
+
+## Join the Ansible community
+Looking for ways to get involved? See [how can I help](https://docs.ansible.com/ansible/devel/community/how_can_I_help.html#how-can-i-help) for some ideas! 
+
+You can find easy issues in [collections](https://github.com/search?q=user:ansible-collections+label:easyfix,"good+first+issue"+state:open&type=Issues) and [other projects](https://github.com/search?q=user:ansible+user:ansible-community+label:easyfix,"good+first+issue"+state:open&type=Issues) for code or documentation contributions.
+
 
 ## That's all for now!
 

--- a/bots/newsbot-section.md
+++ b/bots/newsbot-section.md
@@ -3,3 +3,7 @@
 {{section.news}}
 
 {{section.projects}}
+
+## Other events and releases
+
+Use the Ansible Forum to see [other events](https://forum.ansible.com/c/events/8) and [releases](https://forum.ansible.com/c/news/releases/18).


### PR DESCRIPTION
This reverts #28  since the description fields only show up if there is an entry in that category.  What we really need is text that shows up all the time, which is what this PR does.