### PR TITLE
Move boilerplate addition to newsbot-report.md

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -43,7 +43,7 @@ You can also add some information about which section and/or project the news re
 
 See the [newsbot documentation](https://github.com/haecker-felix/hebbot/?tab=readme-ov-file) for how to make changes. 
 * Changes to `newsbot-project.md` or `newsbot-section.md` will impact every section or project.
-* Add text you want to appear in every bullhorn to `newsbot-section.md`.
+* Add text you want to appear in every Bullhorn edition to `newsbot-section.md`.
 
 If you've made changes here for @newsbot, you need to tell the bot to reload the config from GitHub.
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -41,7 +41,9 @@ You can also add some information about which section and/or project the news re
 
 ### Updating newsbot
 
-See the [newsbot documentation](https://github.com/haecker-felix/hebbot/?tab=readme-ov-file) for how to make changes.
+See the [newsbot documentation](https://github.com/haecker-felix/hebbot/?tab=readme-ov-file) for how to make changes. 
+* Changes to `newsbot-project.md` or `newsbot-section.md` will impact every section or project.
+* Add text you want to appear in every bullhorn to `newsbot-section.md`.
 
 If you've made changes here for @newsbot, you need to tell the bot to reload the config from GitHub.
 

--- a/bots/newsbot-report.md
+++ b/bots/newsbot-report.md
@@ -15,6 +15,10 @@ Welcome to [The Bullhorn](https://forum.ansible.com/c/news/bullhorn/17), our new
 
 {{sections}}
 
+## Other events and releases
+
+Use the Ansible Forum to see [other events](https://forum.ansible.com/c/events/8) and [releases](https://forum.ansible.com/c/news/releases/18).
+
 ## Join the Ansible community
 Looking for ways to get involved? See [how can I help](https://docs.ansible.com/ansible/devel/community/how_can_I_help.html#how-can-i-help) for some ideas! 
 

--- a/bots/newsbot-section.md
+++ b/bots/newsbot-section.md
@@ -3,7 +3,3 @@
 {{section.news}}
 
 {{section.projects}}
-
-## Other events and releases
-
-Use the Ansible Forum to see [other events](https://forum.ansible.com/c/events/8) and [releases](https://forum.ansible.com/c/news/releases/18).


### PR DESCRIPTION
Ends up if you add text to the *section or *project.md file, it appears after every section or project (aka multiple times).

That wasn't the desired effect so moving this text to the newsbot-report.md instead so it only appears once.